### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
 
   def index
-    @items = Item.all
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to items_path(item) do %>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
            <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,25 +128,26 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to items_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+           <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
+      <% end %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +156,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.blank? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +175,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
+
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
## What
- **商品一覧表示機能の追加**: 
  - トップページに出品商品一覧表示機能を実装
  - 商品が存在する場合は一覧表示、ない場合はダミー商品を表示

## Why
- **ユーザーエクスペリエンス向上**: 
　商品一覧はフリマサイトの主要機能であり、ユーザーが新着商品を見つけ、購入に至るための重要なステップとしてユーザーエクスペリエンスを向上させるため

- **デザイン統一性**: 
　出品商品を一覧画面としての統一されたデザインで表示することが、ユーザーにとって使いやすいサイトを提供する上で重要であるため

## gyazo動画リンク
▼商品のデータがない場合は、ダミー商品が表示されている動画
　https://gyazo.com/1fc2c6d0594ace8b59e6345ab511af1a

▼商品のデータがある場合は、商品が一覧で表示されている動画
（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
　https://gyazo.com/4070dea31037c23a7e81f81fae009111
