### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
            <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image.variant(resize: '500x500') ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,55 +16,53 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+       ¥<%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in? %>
+      <%# ログイン状態且つ、自身が出品した販売中商品の場合にのみ、「商品の編集」「削除」ボタンが表示される %>
+      <% if user_signed_in? && current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%# ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示される %>
+    <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end %>
+   <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.item_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_from.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_time.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,9 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.item_category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,9 +26,9 @@
     <% if user_signed_in? %>
       <%# ログイン状態且つ、自身が出品した販売中商品の場合にのみ、「商品の編集」「削除」ボタンが表示される %>
       <% if user_signed_in? && current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
-        <p class="or-text">or</p>
-        <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+         <p class="or-text">or</p>
+         <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
       <%# ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示される %>
     <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
## What
- **商品詳細表示機能の追加**: 
  - 商品の詳細情報、画像、価格、出品者情報などの表示
  - トップページの出品商品一覧について、各商品詳細ページへのリンクを設定
  - ログイン状態且つユーザー自身が出品した商品について、編集・削除ボタンが表示されるように設定
  - ログイン状態且つユーザー自身が出品していない商品について、購入ボタンが表示されるように設定

## Why
- **ユーザーエクスペリエンス向上**: 
　商品詳細情報はフリマサイトでユーザーが商品購入を検討する際に重要であるため

- **操作フローを改善**: 
　出品商品を一覧画面／詳細ページに分けて表示する事で、ユーザーのスムーズな操作と情報提供を実現するため

## gyazo動画リンク
▼ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
  https://gyazo.com/420896d3e40dd5a2fc84aec91881491b

▼ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
  https://gyazo.com/5d319d3fba6b0c5295293c26e87a41a0

▼ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
  ※未実装

▼ログアウト状態で、商品詳細ページへ遷移した動画
　https://gyazo.com/752524ac83c73ef81eb2f9cc4ec68f77