### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -34,6 +34,15 @@ class ItemsController < ApplicationController
   end
 
   def show
+  end
+
+  def destroy
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if user_signed_in? && current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
          <p class="or-text">or</p>
-         <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+          <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
       <%# ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示される %>
     <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
## What
- **商品削除機能の追加**: 
  - 商品削除機能を実装
  - ログイン状態且つユーザー自身が出品した商品について、商品詳細ページに「商品の削除」ボタンが表示されるように設定
  - 商品を削除するとトップページに遷移するように設定　
## Why
- **ユーザービリティ向上**: 
　商品削除機能は、フリマサイトでユーザーが商品出品の取りやめを行う際に必要であるため

- **柔軟な商品管理**: 
　商品の柔軟な出品／出品取りやめを可能にし、ユーザーのニーズに合わせた商品管理を可能とするため

## gyazo動画リンク

▼ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
①ログインしているユーザー（M3）が自身の商品を削除するとトップページに遷移
　https://gyazo.com/a8390042baf97682911e1fd77cf8f1b7
②トップページから当該商品（鳥）が削除されている
　https://gyazo.com/9ada84d83edeac7da22adee5bfdd9a8c
