### PR TITLE
商品購入機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,7 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+
+gem 'payjp'
+
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.6.20240107)
     erubi (1.12.0)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
@@ -110,6 +111,14 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -139,10 +148,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.1205)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.4.9)
       date
@@ -153,6 +166,7 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.0)
     nokogiri (1.16.0-x86_64-darwin)
       racc (~> 1.4)
@@ -163,6 +177,8 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.13)
+      rest-client (~> 2.0)
     pg (1.5.4)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -213,9 +229,16 @@ GEM
     regexp_parser (2.8.3)
     reline (0.4.1)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -305,11 +328,13 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gon
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
+  payjp
   pg
   pry-rails
   puma (~> 5.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    return if @item.user_id == current_user.id
+    return if @item.user_id == current_user.id && @item.order.nil?
 
     redirect_to root_path
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,43 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+    @order_shipping = OrderShipping.new
+    @item = Item.find(params[:item_id])
+    redirect_to root_path if current_user.id == @item.user_id || @item.order.present?
+  end
+
+  def create
+    @order_shipping = OrderShipping.new(order_params)
+    @item = Item.find(params[:item_id])
+
+    if @order_shipping.valid?
+      pay_item
+      shipping_from = ShippingFrom.find(@order_shipping.shipping_from_id)
+      @order_shipping.save(shipping_from) # 引数 shipping_from を渡す
+
+      redirect_to root_path
+    else
+      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+      puts @order_shipping.errors.full_messages
+      render 'index', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def order_params
+    params.require(:order_shipping).permit(:zip_code, :shipping_from_id, :municipality, :house_number, :building_name,
+     :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+
+  def pay_item
+    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+    Payjp::Charge.create(
+      amount: @item.price, # 商品の値段
+      card: order_params[:token], # カードトークン
+      currency: 'jpy' # 通貨の種類（日本円）
+    )
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,17 +1,15 @@
 class OrdersController < ApplicationController
   before_action :authenticate_user!
+  before_action :find_item, only: [:index, :create]
 
   def index
     gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
     @order_shipping = OrderShipping.new
-    @item = Item.find(params[:item_id])
     redirect_to root_path if current_user.id == @item.user_id || @item.order.present?
   end
 
   def create
     @order_shipping = OrderShipping.new(order_params)
-    @item = Item.find(params[:item_id])
-
     if @order_shipping.valid?
       pay_item
       shipping_from = ShippingFrom.find(@order_shipping.shipping_from_id)
@@ -39,5 +37,10 @@ class OrdersController < ApplicationController
       card: order_params[:token], # カードトークン
       currency: 'jpy' # 通貨の種類（日本円）
     )
+  end
+
+  def find_item
+    @item = Item.find(params[:item_id])
+    redirect_to root_path if current_user.id == @item.user_id || @item.order.present?
   end
 end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
-
+import "card"
 import "item_price"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,5 +1,4 @@
 const pay = () => {
-  console.log("OK")
   const publicKey = gon.public_key
   const payjp = Payjp(publicKey) // PAY.JPテスト公開鍵
   const elements = payjp.elements();

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,33 @@
+const pay = () => {
+  console.log("OK")
+  const publicKey = gon.public_key
+  const payjp = Payjp(publicKey) // PAY.JPテスト公開鍵
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+  const form = document.getElementById('charge-form')
+  form.addEventListener("submit", (e) => {
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });
+    e.preventDefault();
+  });
+};
+
+window.addEventListener("turbo:load", pay);
+window.addEventListener("turbo:render", pay);

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
 
   belongs_to :user
+  has_one    :order
 
   has_one_attached :image
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :shipping
+end

--- a/app/models/order_shipping.rb
+++ b/app/models/order_shipping.rb
@@ -1,0 +1,21 @@
+class OrderShipping
+  include ActiveModel::Model
+  attr_accessor :zip_code, :shipping_from_id, :municipality, :house_number, :building_name, :phone_number, :user_id, :item_id, :token
+
+  with_options presence: true do
+    validates :zip_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
+    validates :shipping_from_id, numericality: {other_than: 0, message: "can't be blank"}
+    validates :municipality
+    validates :house_number
+    validates :phone_number, format: {with: /\A[0-9]{11}\z/, message: "is invalid"}
+    validates :user_id
+    validates :item_id
+    validates :token
+  end
+
+  def save(shipping_from)
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Shipping.create(zip_code: zip_code, shipping_from_id: shipping_from.id, municipality: municipality,
+                    house_number: house_number, building_name: building_name, phone_number: phone_number, order_id: order.id)
+  end
+end

--- a/app/models/order_shipping.rb
+++ b/app/models/order_shipping.rb
@@ -7,11 +7,13 @@ class OrderShipping
     validates :shipping_from_id, numericality: {other_than: 0, message: "can't be blank"}
     validates :municipality
     validates :house_number
-    validates :phone_number, format: {with: /\A[0-9]{11}\z/, message: "is invalid"}
+    validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: "is invalid" }
     validates :user_id
     validates :item_id
     validates :token
   end
+
+  validates :building_name, allow_blank: true, length: { maximum: 255 }
 
   def save(shipping_from)
     order = Order.create(user_id: user_id, item_id: item_id)

--- a/app/models/shipping.rb
+++ b/app/models/shipping.rb
@@ -1,0 +1,3 @@
+class Shipping < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
+  has_many :orders
 
   validates :nickname, presence: true
  

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,11 +134,11 @@
         <div class='item-img-content'>
            <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <% if item.order != nil %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <% end %>
       <% end %>
 
         </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -6,13 +6,14 @@
     <h2 class="name">
       <%= @item.item_name %>
     </h2>
-    <div class="item-img-content">
-      <%= image_tag @item.image.variant(resize: '500x500') ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
+<div class="item-img-content">
+      <%= image_tag @item.image.variant(resize: '500x500'), class: "item-box-img" %>
+      <% if @item.order != nil %>
+      <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %> 
+</div>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -25,14 +26,14 @@
 
     <% if user_signed_in? %>
       <%# ログイン状態且つ、自身が出品した販売中商品の場合にのみ、「商品の編集」「削除」ボタンが表示される %>
-      <% if user_signed_in? && current_user.id == @item.user_id %>
+      <% if user_signed_in? && current_user.id == @item.user_id && @item.order.nil? %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
          <p class="or-text">or</p>
           <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
-      <%# ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示される %>
-    <% else %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <% end %>
+      <% elsif @item.order.present? %>
+      <% else %>
+        <%= link_to "購入画面に進む", item_orders_path(@item) ,class:"item-red-btn"%>
+      <% end %>
    <% end %>
 
     <div class="item-explain-box">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
 </head>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @item.image.variant(resize: '500x500') ,class:"buy-item-img" %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.item_name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_fee.name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +26,17 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @item.price %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+<%= include_gon %>
+
+    <%= form_with model: @order_shipping, url: item_orders_path(@item),id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+  
+    <%= render 'shared/error_messages', model: f.object %>
+      
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -79,42 +84,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :zip_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:shipping_from_id, ShippingFrom.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :municipality, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :house_number, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building_name, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.active_job.queue_adapter = :inline #追記
 end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,5 +5,5 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
-
+pin "card", to: "card.js"
 pin "item_price", to: "item_price.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index' 
-  resources :items
+  resources :items do
+    resources :orders, only: [:index, :create]
+   end
 end

--- a/db/migrate/20240119105956_create_orders.rb
+++ b/db/migrate/20240119105956_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240119111048_create_shippings.rb
+++ b/db/migrate/20240119111048_create_shippings.rb
@@ -1,0 +1,14 @@
+class CreateShippings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shippings do |t|
+      t.string  :zip_code, null: false
+      t.integer :shipping_from_id, null: false
+      t.string  :municipality, null: false
+      t.string  :house_number, null: false
+      t.string  :building_name
+      t.string  :phone_number, null: false
+      t.references :order, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_15_081029) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_19_111048) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -54,6 +54,28 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_15_081029) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "orders", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
+  create_table "shippings", charset: "utf8", force: :cascade do |t|
+    t.string "zip_code", null: false
+    t.integer "shipping_from_id", null: false
+    t.string "municipality", null: false
+    t.string "house_number", null: false
+    t.string "building_name"
+    t.string "phone_number", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_shippings_on_order_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -75,4 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_15_081029) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
+  add_foreign_key "shippings", "orders"
 end

--- a/spec/factories/order_shippings.rb
+++ b/spec/factories/order_shippings.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :order_shipping do
+   zip_code { '123-4567' }
+   shipping_from_id { rand(1..47) }
+   municipality { '渋谷区' }
+   house_number { '代々木1-1-1' }
+   phone_number { '09012345678' }
+   token {"tok_abcdefghijk00000000000000000"}
+  end
+end

--- a/spec/factories/order_shippings.rb
+++ b/spec/factories/order_shippings.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
    shipping_from_id { rand(1..47) }
    municipality { '渋谷区' }
    house_number { '代々木1-1-1' }
+   building_name { 'アジアビル' }
    phone_number { '09012345678' }
    token {"tok_abcdefghijk00000000000000000"}
   end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/factories/shippings.rb
+++ b/spec/factories/shippings.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :shipping do
+    
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_shipping_spec.rb
+++ b/spec/models/order_shipping_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe OrderShipping, type: :model do
+  before do
+    @user = FactoryBot.create(:user)
+    @item = FactoryBot.create(:item)
+    @order_shipping = FactoryBot.build(:order_shipping, user_id: @user.id, item_id: @item.id)
+  end
+
+  describe '購入内容の確認' do
+    context '購入成功' do
+      it 'すべての項目の入力について問題なし' do
+        expect(@order_shipping).to be_valid
+      end
+    end
+
+    context '購入失敗' do
+      it '郵便番号が空では登録できない' do
+        @order_shipping.zip_code = ''
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Zip code can't be blank")
+      end
+      it '郵便番号はハイフンを含まないと登録できない' do
+        @order_shipping.zip_code = '1234567' # ハイフンがない場合
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Zip code is invalid. Include hyphen(-)")
+      end
+      it '郵便番号は「3桁ハイフン4桁」の半角文字列でないと登録できない' do
+        @order_shipping.zip_code = '123-456' # 長さが足りない場合
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Zip code is invalid. Include hyphen(-)")
+      end
+
+      it '都道府県が空では登録できない' do
+        @order_shipping.shipping_from_id = 0
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Shipping from can't be blank")
+      end
+
+      it '市区町村が空では登録できない' do
+        @order_shipping.municipality = ''
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Municipality can't be blank")
+      end
+
+      it '番地が空では登録できない' do
+        @order_shipping.house_number = ''
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("House number can't be blank")
+      end
+
+      it '電話番号が空では登録できない' do
+        @order_shipping.phone_number = ''
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Phone number can't be blank")
+      end
+      it '電話番号は10 or 11桁でないと登録できない' do
+        @order_shipping.phone_number = '123456789012' # 12桁の場合
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Phone number is invalid")
+      end
+      it '電話番号は半角数字でないと登録できない' do
+        @order_shipping.phone_number = '123-456-7890' # 数字以外が含まれる場合
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Phone number is invalid")
+      end
+      it 'ユーザーが紐付いていなければ投稿できない' do
+        @order_shipping.user_id = nil
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("User can't be blank")
+      end
+
+      it '商品が紐付いていなければ投稿できない' do
+        @order_shipping.item_id = nil
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Item can't be blank")
+      end
+
+      it 'tokenが空では登録できないこと' do
+        @order_shipping.token = nil
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Token can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/order_shipping_spec.rb
+++ b/spec/models/order_shipping_spec.rb
@@ -9,9 +9,14 @@ RSpec.describe OrderShipping, type: :model do
 
   describe '購入内容の確認' do
     context '購入成功' do
-      it 'すべての項目の入力について問題なし' do
-        expect(@order_shipping).to be_valid
-      end
+     it 'すべての項目の入力について問題なし' do
+       expect(@order_shipping).to be_valid
+     end
+
+     it '建物名が空でも登録できる' do
+       @order_shipping.building_name = ''
+       expect(@order_shipping).to be_valid
+     end
     end
 
     context '購入失敗' do
@@ -54,8 +59,13 @@ RSpec.describe OrderShipping, type: :model do
         @order_shipping.valid?
         expect(@order_shipping.errors.full_messages).to include("Phone number can't be blank")
       end
-      it '電話番号は10 or 11桁でないと登録できない' do
-        @order_shipping.phone_number = '123456789012' # 12桁の場合
+      it '電話番号は10 or 11桁でないと登録できない（12桁の場合）' do
+        @order_shipping.phone_number = '123456789012'
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Phone number is invalid")
+      end
+      it '電話番号は10 or 11桁でないと登録できない（9桁の場合）' do
+        @order_shipping.phone_number = '123456789'
         @order_shipping.valid?
         expect(@order_shipping.errors.full_messages).to include("Phone number is invalid")
       end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/shipping_spec.rb
+++ b/spec/models/shipping_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Shipping, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
## What
- **商品購入機能の追加**: 
  - 商品購入機能を実装
  - 配送先情報入力フォームの設定
  - カード決済機能（PAY.JP）の導入
  - 売却済み商品への「sold out」表示設定

## Why
- **ユーザービリティ向上**: 
  - 商品購入機能は、フリマサイトをユーザーが利用する際に必須であるため
  - 売却済み商品に「sold out」表示を設定する事で、ユーザーのスムーズな商品選択をサポート

- **カード決済機能**: 
　ユーザーに安全で迅速な決済手段を提供するため

## gyazo動画リンク
▼ 必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
　https://gyazo.com/0a9498287e0337b65e17e950bf09620a

▼ 入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/11ad95279cd961dc7c3e357357e60dc6

▼ ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/f437e4f9ea9bda676e5aa84ca6d4f564

▼ ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/b0a5c32a3485a000f04fa3b8d0331c14

▼ ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
 https://gyazo.com/72ac6fb054b124dcbca1e447c5b2b049

▼ 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
▼ 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
※上記2条件まとめて動画撮影（以下2つに分割）
①購入前（一覧ページ→詳細ページ→購入画面）
　https://gyazo.com/1ab073dc0c15c77189b632237a48da93
②売却済み（購入処理→一覧ページ→詳細ページ）
　https://gyazo.com/bc5373051da96dc00762c2f2cf45e880

▼ ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
①「購入画面に進む」ボタンが表示されない（自身が出品していない商品）
　https://gyazo.com/2d510773710478fa3de6df67a6ddf4bc
②「商品の編集」「削除」ボタンが表示されない（自身が出品した商品）
　https://gyazo.com/0a610d84b8784c0474421b7213a12ff4

▼ ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
   https://gyazo.com/ad552bf12c6621f3261b98a912e9ebc0

▼ テスト結果の画像
　https://gyazo.com/ee20e719e6b860d1064e4fea45542ad1